### PR TITLE
add command parameter number configurable feature

### DIFF
--- a/shell.h
+++ b/shell.h
@@ -90,10 +90,11 @@
             {                                                               \
                 shellCmd##cmd,                                              \
                 (int (*)())func,                                            \
+                0,                                                          \
                 shellDesc##cmd,                                             \
                 (void *)0                                                   \
             }
-#define     SHELL_EXPORT_CMD_EX(cmd, func, desc, help)                      \
+#define     SHELL_EXPORT_CMD_EX(cmd, func, param_num, desc, help)           \
             const char shellCmd##cmd[] = #cmd;                              \
             const char shellDesc##cmd[] = #desc;                            \
             const char shellHelp##cmd[] = #help;                            \
@@ -102,6 +103,7 @@
             {                                                               \
                 shellCmd##cmd,                                              \
                 (int (*)())func,                                            \
+                param_num,                                                  \
                 shellDesc##cmd,                                             \
                 shellHelp##cmd                                              \
             }
@@ -114,9 +116,10 @@
             {                                                               \
                 shellCmd##cmd                                               \
                 (int (*)())func,                                            \
+                0,                                                          \
                 shellDesc##cmd                                              \
             }
-#define     SHELL_EXPORT_CMD_EX(cmd, func, desc, help)                      \
+#define     SHELL_EXPORT_CMD_EX(cmd, func, param_num, desc, help)           \
             const char shellCmd##cmd[] = #cmd;                              \
             const char shellDesc##cmd[] = #desc;                            \
             const SHELL_CommandTypeDef                                      \
@@ -124,6 +127,7 @@
             {                                                               \
                 shellCmd##cmd,                                              \
                 (int (*)())func,                                            \
+                param_num,                                                  \
                 shellDesc##cmd                                              \
             }
 #endif /** SHELL_LONG_HELP == 1 */
@@ -136,7 +140,7 @@
             shellVariable##var SECTION("shellVariable") =                   \
             {                                                               \
                 shellVar##var,                                              \
-                (void *)(variable),                                            \
+                (void *)(variable),                                         \
                 shellDesc##var,                                             \
                 type                                                        \
             }
@@ -146,7 +150,7 @@
 
 #else
 #define     SHELL_EXPORT_CMD(cmd, func, desc)
-#define     SHELL_EXPORT_CMD_EX(cmd, func, desc, help)
+#define     SHELL_EXPORT_CMD_EX(cmd, func, param_num, desc, help)
 #define     SHELL_EXPORT_VAR(var, variable, desc, type) 
 #endif /** SHELL_USING_CMD_EXPORT == 1 */
 
@@ -173,13 +177,15 @@
             {                                                               \
                 #cmd,                                                       \
                 (int (*)())func,                                            \
+                0,                                                          \
                 #desc,                                                      \
                 (void *)0                                                   \
             }
-#define     SHELL_CMD_ITEM_EX(cmd, func, desc, help)                        \
+#define     SHELL_CMD_ITEM_EX(cmd, func, param_num, desc, help)             \
             {                                                               \
                 #cmd,                                                       \
                 (int (*)())func,                                            \
+                param_num,                                                  \
                 #desc,                                                      \
                 #help                                                       \
             }   
@@ -188,12 +194,14 @@
             {                                                               \
                 #cmd,                                                       \
                 (int (*)())func,                                            \
+                0,                                                          \
                 #desc                                                       \
             }
-#define     SHELL_CMD_ITEM_EX(cmd, func, desc, help)                        \
+#define     SHELL_CMD_ITEM_EX(cmd, func, param_num, desc, help)             \
             {                                                               \
                 #cmd,                                                       \
                 (int (*)())func,                                            \
+                param_num,                                                  \
                 #desc,                                                      \
             }  
 #endif /** SHELL_LONG_HELP == 1 */
@@ -260,6 +268,7 @@ typedef struct
 {
     const char *name;                                           /**< shell命令名称 */
     shellFunction function;                                     /**< shell命令函数 */
+    const int  param_num;                                       /**< shell命令参数数量, 0 表示 auto */
     const char *desc;                                           /**< shell命令描述 */
 #if SHELL_LONG_HELP == 1
     const char *help;                                           /**< shell长帮助信息 */


### PR DESCRIPTION
add command parameter number configurable feature.
加入了命令参数数量可配置的特性。
without this feature, when a command requiring more parameter is called, the unassigned parameter may be random.
如果执行的命令需要更多参数，而命令行提供参数不足，那么命令执行时未给出的参数是随机的。
with this feature added, the unassigned parameter of the command would be zero.
增加本特性后，未指派参数是特定值（数值0）。