### PR TITLE
增加登录密码功能，通过cfg文件配置。

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ shellInit(&shell);
 
 4. 说明
 
-- 对于中断方式使用shell，不用定义shell->read，但需要在中断中调用shellHandler
+- 对于中断方式使用shell，不用定义shell->read，但需要在中断中调用shellInput
 - 对于在无操作系统环境下，可以使用查询的方式，使能```SHELL_UISNG_TASK```，然后在循环中不断调用shellTask
 - 对于使用操作系统的情况，使能```SHELL_USING_TASK```和```SHEHLL_TASK_WHILE```宏，然后创建shellTask任务
 - 打印函数返回值，使能```SHELL_DISPLAY_RETURN```宏，返回值均作为整型数据打印

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - 长帮助补全，输入命令后双击tab键补全命令长帮助指令
 - 快捷键，支持使用Ctrl + A~Z组合按键直接调用函数
 - shell变量，支持在shell中查看和修改变量值，支持变量作为命令参数
+- 登录密码，支持在shell中使用登录密码
 
 ## 移植说明
 
@@ -80,6 +81,8 @@ shell.h文件中包含几个用于配置shell的宏，在使用前，需要根�
 | SHELL_GET_TICK()           | 获取系统时间(ms)               |
 | SHELL_DEFAULT_COMMAND      | shell默认提示符                |
 | SHELL_MAX_NUMBER           | 管理的最大shell数量            |
+| SHELL_USING_AUTH           | 是否使用密码功能               |
+| SHELL_USER_PASSWORD        | 用户密码                       |
 
 ## 使用方式
 

--- a/shell.h
+++ b/shell.h
@@ -14,6 +14,12 @@
 
 #include "shell_cfg.h"
 
+#if SHELL_USING_AUTH == 1
+    #if !defined(SHELL_USER_PASSWORD)
+        #error "please config shell user password (int shell_cfg.h) "
+    #endif  
+#endif      
+
 #define     SHELL_VERSION               "2.0.5"                 /**< 版本号 */
 
 /**
@@ -309,6 +315,9 @@ typedef struct
     unsigned char isActive;                                     /**< 是否是当前活动shell */
     shellRead read;                                             /**< shell读字符 */
     shellWrite write;                                           /**< shell写字符 */
+#if SHELL_USING_AUTH == 1
+    char isPasswordConfirm;                                     /**< shell密码标志 */
+#endif 
 }SHELL_TypeDef;
 
 
@@ -335,7 +344,7 @@ void shellSetKeyFuncList(SHELL_TypeDef *shell, SHELL_KeyFunctionDef *base, unsig
 SHELL_TypeDef *shellGetCurrent(void);
 void shellPrint(SHELL_TypeDef *shell, char *fmt, ...);
 unsigned short shellDisplay(SHELL_TypeDef *shell, const char *string);
-void shellHandler(SHELL_TypeDef *shell, char data);
+void shellInput(SHELL_TypeDef *shell, char data);
 
 
 void shellHelp(int argc, char *argv[]);

--- a/shell_cfg.h
+++ b/shell_cfg.h
@@ -103,4 +103,16 @@
  */
 #define     SHELL_DEFAULT_COMMAND       "\r\nletter>>"
 
+
+/**
+ * @brief 是否使用密码功能
+ */
+#define     SHELL_USING_AUTH             0
+
+
+/**
+ * @brief shell用户密码
+ */
+#define     SHELL_USER_PASSWORD         "letter"
+
 #endif


### PR DESCRIPTION
1、【增加】SHELL_USING_AUTH/SHELL_USER_PASSWORD两个配置于cfg文件中，用于配置登陆密码功能；
2、【增加】以前的shellHander函数更改为shellInput函数，即现在外部调用shellInput函数，这个更改作者你可以再斟酌一下；
3、【增加】密码确认功能在shellEnter函数中；
4、【增加】shellCheck函数，由shellHander删减得来，快捷键只响应enter键和backspace键，判断的函数；
5、【更新】readme文档，增加登陆密码相应选项；