### PR TITLE
Shell 命令输入参数超过8个时指针会越界导致HardFault_Handler

### DIFF
--- a/src/shell.c
+++ b/src/shell.c
@@ -851,13 +851,11 @@ static void shellParserParam(Shell *shell)
             }
             if (record == 1)
             {
-                //TODO 防止shell->parser.param[]越界
                 if (shell->parser.paramCount < SHELL_PARAMETER_MAX_NUMBER)
                 {
-                    shell->parser.param[shell->parser.paramCount] =
+                    shell->parser.param[shell->parser.paramCount++] =
                         &(shell->parser.buffer[i]);
                 }
-                shell->parser.paramCount++;
                 record = 0;
             }
             if (shell->parser.buffer[i] == '\\'
@@ -872,11 +870,6 @@ static void shellParserParam(Shell *shell)
             record = 1;
         }
     }
-	//TODO 防止shell->parser.param[]越界 自动截断多余计数
-	if (shell->parser.paramCount > SHELL_PARAMETER_MAX_NUMBER)
-	{
-		shell->parser.paramCount = SHELL_PARAMETER_MAX_NUMBER;
-	}
 }
 
 

--- a/src/shell.c
+++ b/src/shell.c
@@ -872,6 +872,11 @@ static void shellParserParam(Shell *shell)
             record = 1;
         }
     }
+	//TODO 防止shell->parser.param[]越界 自动截断多余计数
+	if (shell->parser.paramCount > SHELL_PARAMETER_MAX_NUMBER)
+	{
+		shell->parser.paramCount = SHELL_PARAMETER_MAX_NUMBER;
+	}
 }
 
 
@@ -883,12 +888,6 @@ static void shellParserParam(Shell *shell)
 static void shellRemoveParamQuotes(Shell *shell)
 {
     unsigned short paramLength;
-    //TODO 防止shell->parser.param[]越界 自动截断多余参数
-    if (shell->parser.paramCount > SHELL_PARAMETER_MAX_NUMBER)
-    {
-        shell->parser.paramCount = SHELL_PARAMETER_MAX_NUMBER;
-    }
-
     for (unsigned short i = 0; i < shell->parser.paramCount; i++)
     {
         if (shell->parser.param[i][0] == '\"')

--- a/src/shell.c
+++ b/src/shell.c
@@ -851,8 +851,13 @@ static void shellParserParam(Shell *shell)
             }
             if (record == 1)
             {
-                shell->parser.param[shell->parser.paramCount ++] = 
-                    &(shell->parser.buffer[i]);
+                //TODO 防止shell->parser.param[]越界
+                if (shell->parser.paramCount < SHELL_PARAMETER_MAX_NUMBER)
+                {
+                    shell->parser.param[shell->parser.paramCount] =
+                        &(shell->parser.buffer[i]);
+                }
+                shell->parser.paramCount++;
                 record = 0;
             }
             if (shell->parser.buffer[i] == '\\'
@@ -878,6 +883,12 @@ static void shellParserParam(Shell *shell)
 static void shellRemoveParamQuotes(Shell *shell)
 {
     unsigned short paramLength;
+    //TODO 防止shell->parser.param[]越界 自动截断多余参数
+    if (shell->parser.paramCount > SHELL_PARAMETER_MAX_NUMBER)
+    {
+        shell->parser.paramCount = SHELL_PARAMETER_MAX_NUMBER;
+    }
+
     for (unsigned short i = 0; i < shell->parser.paramCount; i++)
     {
         if (shell->parser.param[i][0] == '\"')

--- a/src/shell_ext.c
+++ b/src/shell_ext.c
@@ -304,6 +304,11 @@ int shellExtRun(Shell *shell, ShellCommand *command, int argc, char *argv[])
     unsigned int params[8] = {0};
     int paramNum = command->attr.attrs.paramNum > (argc - 1) ? 
         command->attr.attrs.paramNum : (argc - 1);
+    //TODO 防止 params[8]越界
+    if (SHELL_PARAMETER_MAX_NUMBER < argc)
+    {
+        return -1;
+    }
     for (int i = 0; i < argc - 1; i++)
     {
         params[i] = shellExtParsePara(shell, argv[i + 1]);

--- a/src/shell_ext.c
+++ b/src/shell_ext.c
@@ -304,11 +304,6 @@ int shellExtRun(Shell *shell, ShellCommand *command, int argc, char *argv[])
     unsigned int params[8] = {0};
     int paramNum = command->attr.attrs.paramNum > (argc - 1) ? 
         command->attr.attrs.paramNum : (argc - 1);
-    //TODO 防止 params[8]越界
-    if (SHELL_PARAMETER_MAX_NUMBER < argc)
-    {
-        return -1;
-    }
     for (int i = 0; i < argc - 1; i++)
     {
         params[i] = shellExtParsePara(shell, argv[i + 1]);


### PR DESCRIPTION
shell_def的定义只有SHELL_PARAMETER_MAX_NUMBER （8）个
```
typedef struct shell_def
{
***
    struct
    {
        unsigned short length;                                  /**< 输入数据长度 */
        unsigned short cursor;                                  /**< 当前光标位置 */
        char *buffer;                                           /**< 输入缓冲 */
        char *param[SHELL_PARAMETER_MAX_NUMBER];                /**< 参数 */<<-----这里
        unsigned short bufferSize;                              /**< 输入缓冲大小 */
        unsigned short paramCount;                              /**< 参数数量 */
        int keyValue;                                           /**< 输入按键键值 */
    } parser;
***
} Shell;
```

```
static void shellRemoveParamQuotes(Shell *shell)
{
    unsigned short paramLength;
    for (unsigned short i = 0; i < shell->parser.paramCount; i++)
    {
        if (shell->parser.param[i][0] == '\"')
        {
            shell->parser.param[i][0] = 0;
            shell->parser.param[i] = &shell->parser.param[i][1];  //<<---这里i大于8就越界
        }
        paramLength = strlen(shell->parser.param[i]);
        if (shell->parser.param[i][paramLength - 1] == '\"')
        {
            shell->parser.param[i][paramLength - 1] = 0;
        }
    }
}

```