### PR TITLE
log模块write函数调用增加尾行模式是否开启判断

### DIFF
--- a/extensions/log/log.c
+++ b/extensions/log/log.c
@@ -103,13 +103,21 @@ static void logWriteBuffer(Log *log, LogLevel level, char *buffer, short len)
                 && logList[i]->active
                 && logList[i]->level >= level)
             {
+#if SHELL_SUPPORT_END_LINE == 1
+                shellWriteEndLine(logList[i]->shell, logBuffer, len);
+#else
                 logList[i]->write(logBuffer, len);
+#endif
             }
         }
     }
     else if (log && log->active && log->level >= level)
     {
+#if SHELL_SUPPORT_END_LINE == 1
+        shellWriteEndLine(log->shell, logBuffer, len);
+#else
         log->write(logBuffer, len);
+#endif
     }
 }
 


### PR DESCRIPTION
修改log模块logWriteBuffer函数，增加对SHELL_SUPPORT_END_LINE的判断，分别调用shellWriteEndLine和原有的write函数。