### PR TITLE
为导出命令模式使用GCC LD原生的段起止点符号

### DIFF
--- a/src/shell.c
+++ b/src/shell.c
@@ -39,8 +39,8 @@ SHELL_USED const ShellCommand shellUserDefault SHELL_SECTION("shellCommand") =
     #elif defined(__ICCARM__) || defined(__ICCRX__)
         #pragma section="shellCommand"
     #elif defined(__GNUC__)
-        extern const unsigned int _shell_command_start;
-        extern const unsigned int _shell_command_end;
+        extern const unsigned int __start_shellCommand;
+        extern const unsigned int __stop_shellCommand;
     #endif
 #else
     extern const ShellCommand shellCommandList[];
@@ -212,9 +212,9 @@ void shellInit(Shell *shell, char *buffer, unsigned short size)
                                 - (size_t)(__section_begin("shellCommand")))
                                 / sizeof(ShellCommand);
     #elif defined(__GNUC__)
-        shell->commandList.base = (ShellCommand *)(&_shell_command_start);
-        shell->commandList.count = ((size_t)(&_shell_command_end)
-                                - (size_t)(&_shell_command_start))
+        shell->commandList.base = (ShellCommand *)(&__start_shellCommand);
+        shell->commandList.count = ((size_t)(&__stop_shellCommand)
+                                - (size_t)(&__start_shellCommand))
                                 / sizeof(ShellCommand);
     #else
         #error not supported compiler, please use command table mode


### PR DESCRIPTION
LD会为每个能生成为合法C符号名的段生成`__start_段名`和`__stop_段名`的符号，借此可以实现不需修改ldscript的导出命令模式。

参考：https://stackoverflow.com/questions/16552710/how-do-you-get-the-start-and-end-addresses-of-a-custom-elf-section

效果：
<img width="1680" alt="LetterShellGCC" src="https://github.com/NevermindZZT/letter-shell/assets/49363666/b2633d06-dc03-4780-93b3-40148be317d3">
