### PR TITLE
修复 README.md文档中给出的main函数形式例程错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ letter shell 3.x同时支持两种形式的函数定义方式，形如main函数
 使用此方式，一个函数定义的例子如下：
 
 ```C
-int func(int argc, char *agrv[])
+int func(int argc, char *argv[])
 {
     printf("%dparameter(s)\r\n", argc);
     for (char i = 1; i < argc; i++)


### PR DESCRIPTION
虽然只是文档错误，但是通常在首次移植后进行测试时会用到。